### PR TITLE
chore(typescript): enable strict mode

### DIFF
--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -236,14 +236,18 @@ describe('Better Auth authentication (e2e)', () => {
     ).toMatchObject({ role: 'ADMIN' });
     await prisma.$disconnect();
 
-    const [regularLogin, adminLogin, promotedLogin] = await Promise.all(
-      [regularEmail, adminEmail, promotedEmail].map((email) =>
-        request(app.getHttpServer())
-          .post('/api/auth/sign-in/email')
-          .send({ email, password: 'password-123' })
-          .expect(200),
-      ),
-    );
+    // A tuple literal rather than `.map()`, so `Promise.all` resolves to a
+    // fixed-length tuple and each login is typed as present.
+    const signIn = (email: string) =>
+      request(app.getHttpServer())
+        .post('/api/auth/sign-in/email')
+        .send({ email, password: 'password-123' })
+        .expect(200);
+    const [regularLogin, adminLogin, promotedLogin] = await Promise.all([
+      signIn(regularEmail),
+      signIn(adminEmail),
+      signIn(promotedEmail),
+    ]);
     const regularCookie = regularLogin.headers['set-cookie']?.[0] ?? '';
     const adminCookie = adminLogin.headers['set-cookie']?.[0] ?? '';
     const promotedCookie = promotedLogin.headers['set-cookie']?.[0] ?? '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,11 @@
     "outDir": "./dist",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
Closes #25

## Summary

- Enables `strict`, `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess` and `noFallthroughCasesInSwitch`.
- Removes the `nest new` scaffold leftovers that disabled `noImplicitAny`, `strictBindCallApply` and `noFallthroughCasesInSwitch`.
- Fixes the one place the new checks found a real gap.

## Why this is nearly free

The codebase was already written strict-clean; the flags were simply off. Measured before changing anything:

| Configuration | Errors |
|---|---|
| `--strict` over `src/` and `test/` | 0 |
| `--strict --noUnusedLocals --noUnusedParameters` | 0 |
| `--strict --noUncheckedIndexedAccess` | 3 |

A weak compiler default in a template is not this repository's problem — it is inherited by every project generated from it, which is what makes an otherwise cosmetic change worth making.

## The one real finding

`test/e2e/auth.spec.ts` destructured three logins out of `Promise.all` over a mapped array. That resolves to `T[]`, not a tuple, so TypeScript cannot know three elements come back and each was genuinely `T | undefined`. The compiler was right.

Fixed by extracting a `signIn(email)` helper and passing a tuple literal, which `Promise.all` infers as fixed-length:

```ts
const [regularLogin, adminLogin, promotedLogin] = await Promise.all([
  signIn(regularEmail),
  signIn(adminEmail),
  signIn(promotedEmail),
]);
```

Deliberately **not** fixed with `!`. Enabling a check and then silencing it with assertions leaves the ceremony without the guarantee, and misrepresents the project as strict.

## Changes

| File | Change |
|---|---|
| `tsconfig.json` | `strict` on; `strictNullChecks` dropped as a separate entry since `strict` implies it; scaffold's disabled flags removed |
| `test/e2e/auth.spec.ts` | Tuple literal into `Promise.all` so the destructured logins are typed as present |

## Test plan

- [x] `pnpm typecheck` clean (`src/` and `test/`)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [x] `pnpm lint`, `pnpm build` clean
- [x] 82 unit, 2 integration, 29 E2E passing