### PR TITLE
test(e2e): apply migrations instead of restating the schema in test code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,9 +157,11 @@ changes its checksum, so any database that already applied the previous one —
 including your local development database — needs `pnpm exec prisma migrate
 reset` before `prisma migrate dev` will run again.
 
-Keep the hand-written DDL in `test/e2e/auth.spec.ts` in step with the schema.
-That suite creates its tables directly instead of applying migrations, so a new
-model is invisible to it until it is added there by hand.
+`createTestEnvironment` (`test/support/test-environment.ts`) applies the
+committed migrations to every throwaway container, so a suite always runs
+against the real schema and a new model needs no test-side change. Do not
+create tables by hand in a spec: a suite that defines its own shape can pass
+against a database the application would never have.
 
 ## Workflow
 

--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -146,7 +146,10 @@ authentication route contract.
 
 Unit tests are colocated in `src/**/*.spec.ts` and use fakes. Integration tests
 are in `test/integration`, while E2E tests are in `test/e2e`; each E2E file
-creates an isolated PostgreSQL container and schema. The critical seams are:
+creates an isolated PostgreSQL container and schema, then applies the committed
+migrations to it. Tests therefore run against the schema the application
+actually ships, rather than one restated in test code that could drift from it
+and report a false pass. The critical seams are:
 
 | Seam | Evidence |
 | --- | --- |

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -24,31 +24,6 @@ describe('Better Auth authentication (e2e)', () => {
   beforeAll(async () => {
     originalEnvironment = { ...process.env };
     environment = await createTestEnvironment();
-    const prisma = new PrismaClient({
-      adapter: new PrismaPg(
-        { connectionString: environment.databaseUrl },
-        { schema: environment.schema },
-      ),
-    });
-    await prisma.$executeRawUnsafe(
-      `CREATE TYPE "${environment.schema}"."Role" AS ENUM ('USER', 'ADMIN')`,
-    );
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE "${environment.schema}"."user" ("id" TEXT PRIMARY KEY, "name" TEXT NOT NULL, "email" TEXT NOT NULL UNIQUE, "emailVerified" BOOLEAN NOT NULL DEFAULT false, "image" TEXT, "role" "${environment.schema}"."Role" NOT NULL DEFAULT 'USER', "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMPTZ NOT NULL)`,
-    );
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE "${environment.schema}"."session" ("id" TEXT PRIMARY KEY, "expiresAt" TIMESTAMPTZ NOT NULL, "token" TEXT NOT NULL UNIQUE, "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMPTZ NOT NULL, "ipAddress" TEXT, "userAgent" TEXT, "userId" TEXT NOT NULL REFERENCES "${environment.schema}"."user"("id") ON DELETE CASCADE)`,
-    );
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE "${environment.schema}"."account" ("id" TEXT PRIMARY KEY, "accountId" TEXT NOT NULL, "providerId" TEXT NOT NULL, "issuer" TEXT NOT NULL, "userId" TEXT NOT NULL REFERENCES "${environment.schema}"."user"("id") ON DELETE CASCADE, "accessToken" TEXT, "refreshToken" TEXT, "idToken" TEXT, "accessTokenExpiresAt" TIMESTAMPTZ, "refreshTokenExpiresAt" TIMESTAMPTZ, "scope" TEXT, "password" TEXT, "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMPTZ NOT NULL, UNIQUE("issuer", "accountId"))`,
-    );
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE "${environment.schema}"."verification" ("id" TEXT PRIMARY KEY, "identifier" TEXT NOT NULL, "value" TEXT NOT NULL, "expiresAt" TIMESTAMPTZ NOT NULL, "createdAt" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP, "updatedAt" TIMESTAMPTZ NOT NULL)`,
-    );
-    await prisma.$executeRawUnsafe(
-      `CREATE TABLE "${environment.schema}"."rate_limit" ("id" TEXT PRIMARY KEY, "key" TEXT NOT NULL UNIQUE, "count" INTEGER NOT NULL, "lastRequest" BIGINT NOT NULL)`,
-    );
-    await prisma.$disconnect();
     process.env = {
       ...originalEnvironment,
       ...defaultEnvironment,

--- a/test/support/test-environment.ts
+++ b/test/support/test-environment.ts
@@ -1,5 +1,9 @@
+import { execFile as executeFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { promisify } from 'node:util';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
+
+const execFile = promisify(executeFile);
 
 export type TestEnvironment = {
   databaseUrl: string;
@@ -28,6 +32,15 @@ export async function createTestEnvironment(): Promise<TestEnvironment> {
     if (schemaResult.exitCode !== 0) {
       throw new Error('Unable to initialize an isolated PostgreSQL schema');
     }
+
+    // Apply the committed migrations rather than creating tables by hand, so a
+    // suite cannot pass against a shape the real database does not have. For
+    // PostgreSQL, Prisma takes the target schema from the connection string.
+    const migrationUrl = new URL(postgres.getConnectionUri());
+    migrationUrl.searchParams.set('schema', schema);
+    await execFile('pnpm', ['exec', 'prisma', 'migrate', 'deploy'], {
+      env: { ...process.env, DATABASE_URL: migrationUrl.toString() },
+    });
 
     return {
       databaseUrl: postgres.getConnectionUri(),


### PR DESCRIPTION
Closes #27

## The problem

`test/e2e/auth.spec.ts` built its own tables with hand-written `CREATE TABLE`. That shape lived separately from `prisma/schema.prisma`, so the suite could go green against a database the application would never have, and every new model was invisible to it until someone edited the DDL by hand.

That is not a theoretical risk — adding the `rate_limit` model in #24 required exactly that manual edit, and it was caught only because the change was fresh. `AGENTS.md` documented the trap, but a documented trap is still a trap.

## The fix

`createTestEnvironment` applies the committed migrations to every throwaway container.

Placed there rather than in the spec on purpose: it is the nearest common ancestor of both consumers (`test/e2e/auth.spec.ts` and `test/integration/dependencies.spec.ts`), and making it automatic means no future suite can forget to ask for tables. An opt-in flag would rebuild the same trap under a new name.

One detail worth knowing: Prisma takes the target schema for PostgreSQL from the **connection string**, not from `DATABASE_SCHEMA`, so the throwaway schema is passed as a query parameter.

All 25 lines of DDL are deleted with no test-side replacement. The suite now gets its tables from the migration or gets nothing — which is the property being bought.

## Changes

| File | Change |
|---|---|
| `test/support/test-environment.ts` | Runs `prisma migrate deploy` against the container after creating the isolated schema |
| `test/e2e/auth.spec.ts` | 25 lines of DDL removed, no replacement |
| `AGENTS.md`, `docs/EDD.md` | The note describing the hand-written DDL is now false; replaced with the rule that a spec must not define its own tables |

## Test plan

- [x] 29 E2E passing with zero hand-written DDL — had migrations not applied, no table would exist and every test would fail, so the green run is itself the proof
- [x] 82 unit, 2 integration passing
- [x] `pnpm typecheck`, `tsc -p tsconfig.build.json`, lint, build clean
- [x] E2E runtime unchanged in practice (~10s)

## Note for the reviewer

This branch is cut from `main` and does not overlap `refactor/core-feature-dependency-direction`, which is in flight locally — verified with `git diff --name-only`. The two touch disjoint file sets.