### PR TITLE
ci: enforce the core-to-feature dependency boundary

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Verify core does not depend on features
+        run: pnpm verify:boundaries
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ pnpm only. Do not use npm or yarn.
 | integration tests | `pnpm test:integration` |
 | E2E tests | `pnpm test:e2e` |
 | lint | `pnpm lint` |
+| architecture boundary | `pnpm verify:boundaries` |
 | generate Prisma client | `pnpm prisma:generate` |
 | migration | `pnpm prisma:migrate` |
 | apply migrations | `pnpm prisma:deploy` |
@@ -52,7 +53,8 @@ session requirement; `@Roles()` still restricts a route to a `Role`. Nothing
 under `src/core/` or `src/shared/` imports from `src/features/`, so global
 infrastructure stays composable without any business feature; a feature that
 must join the request pipeline implements the `HttpExtension` port
-(`src/core/http/http-extension.ts`) instead. The
+(`src/core/http/http-extension.ts`) instead. `pnpm verify:boundaries` enforces
+that rule and runs in CI, so it fails the build rather than the code review. The
 dependency direction keeps `AuthModule` and `UsersModule` independent:
 `SessionGuard` establishes the principal from the Better Auth session, while
 the current-user profile route resolves its separate public projection through

--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -34,6 +34,11 @@ with the metadata-only `@Public()` decorator instead.
 must join the request pipeline implements the `HttpExtension` port
 (`src/core/http/http-extension.ts`): core keeps ownership of middleware
 ordering, while the feature owns what is mounted and how it documents itself.
+
+`scripts/verify-boundaries.sh` (`pnpm verify:boundaries`) enforces that
+direction and runs as its own CI step. It fails on a violation and also fails
+when the search itself errors, so a missing directory can never be mistaken
+for a clean result.
 `AuthModule` mounts Better Auth independently of `UsersModule`: `SessionGuard`
 resolves the principal from the Better Auth session, while the current-user
 profile route resolves its separate public projection through `UsersService`.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:watch": "vitest --project=unit",
     "test:integration": "vitest run --project=integration",
     "test:e2e": "vitest run --project=e2e",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "verify:boundaries": "bash scripts/verify-boundaries.sh"
   },
   "dependencies": {
     "@better-auth/prisma-adapter": "^1.7.2",

--- a/scripts/verify-boundaries.sh
+++ b/scripts/verify-boundaries.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Global infrastructure must stay composable without any business feature:
+# nothing under src/core/ or src/shared/ may import from src/features/.
+#
+# A feature that has to join the request pipeline implements the HttpExtension
+# port (src/core/http/http-extension.ts) instead, and the composition root
+# (src/app.module.ts) is the one place allowed to know both sides.
+set -uo pipefail
+
+readonly pattern="['\"][^'\"]*features/"
+readonly roots=(src/core src/shared)
+
+matches=$(grep -rnE "$pattern" "${roots[@]}")
+status=$?
+
+case "$status" in
+  1)
+    echo "OK: ${roots[*]} do not reference src/features"
+    ;;
+  0)
+    {
+      echo "Boundary violation: ${roots[*]} must not reference src/features."
+      echo
+      echo "$matches"
+      echo
+      echo "Move the shared piece to src/shared/, or expose it to core through"
+      echo "a port such as src/core/http/http-extension.ts."
+    } >&2
+    exit 1
+    ;;
+  *)
+    echo "grep exited with status $status: the boundary was NOT verified." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Closes #31

## The problem

#30 wrote the rule down. Nothing enforced it. That is the same shape #28 attacked in the E2E suite: a documented trap is still a trap.

## The fix

`scripts/verify-boundaries.sh`, wired as `pnpm verify:boundaries` and as its own CI step after Lint, where it fails fast and costs nothing.

The interesting part is what the script does **not** do. The obvious one-liner is:

```bash
! grep -rE "['\"][^'\"]*features/" src/core src/shared
```

That is wrong. `grep` exits 0 on a match, 1 on no match, and **2 on error** — and `!` turns that 2 into success. Rename a directory, and the guard reports a clean boundary forever while checking nothing. A guard that fails open is worse than no guard, because people trust it.

So all three outcomes are handled explicitly, and the error branch exits 1.

## Proof it actually fails

A guard nobody has seen fail is an assumption. All three were run:

| Scenario | Expected | Result |
|---|---|---|
| Real import of `features/auth/better-auth.service` added to `src/core/health/health.controller.ts` | exit 1 | exit 1, offending line printed |
| Commented-out `features/users` reference added to `src/shared/decorators/public.decorator.ts` | exit 1 | exit 1 |
| Script pointed at a non-existent root directory | exit 1 | exit 1 — `! grep` would have exited **0** here |

The second case is deliberate. The pattern matches any quoted string containing `features/`, so a commented-out import trips it too. That is the trade being made on purpose: a false positive costs seconds, a false negative defeats the guard.

## Changes

| File | Change |
|---|---|
| `scripts/verify-boundaries.sh` | New guard; explicit handling of all three grep exit codes, prints the offending lines and how to fix them |
| `package.json` | `verify:boundaries` script, so the check runs locally exactly as it runs in CI |
| `.github/workflows/pull-request.yml` | New step after Lint |
| `AGENTS.md` | Command table entry; the invariant now says it is enforced |
| `docs/EDD.md` | Documents the guard, including why it fails on a search error |

## Test plan

- [x] All three failure scenarios above verified by hand before committing
- [x] `pnpm verify:boundaries` passes on this branch
- [x] 82 unit, 2 integration, 29 E2E, typecheck, lint, build clean
- [x] Workflow step order confirmed: it sits between Lint and Typecheck

## Note for the reviewer

`grep` is used rather than `rg` on purpose: it is guaranteed present on the runner and on any contributor's machine, and this check must never be the thing that fails for being unavailable. The docs still quote `rg` for humans reading them.
