### PR TITLE
docs(readme): document the boundary command and correct the architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ variables from its deployment platform; `.env` is not loaded when
 | `pnpm build` | Build the production application. |
 | `pnpm lint` | Lint TypeScript and apply fixes. |
 | `pnpm typecheck` | Type-check application and test sources. |
+| `pnpm verify:boundaries` | Verify `src/core/` and `src/shared/` do not import from `src/features/`. |
 | `pnpm test` | Run unit tests. |
 | `pnpm test:integration` | Run PostgreSQL integration tests. |
 | `pnpm test:e2e` | Run HTTP E2E tests. |
@@ -193,11 +194,19 @@ suites.
 The application is a modular monolith. Controllers translate HTTP input to
 services; services own authorization-relevant rules; repositories own
 PostgreSQL access. `PlatformModule` is global and provides configuration,
-logging, Prisma, request IDs, errors, health checks, and shared pagination
-contracts. Better Auth owns native authentication while the starter owns the
-meaning and enforcement of `USER` and `ADMIN` roles, kept independent through
-`AccessControlModule`'s global guard chain (`RateLimitGuard` →
-`SessionGuard` → `RolesGuard` → `OriginGuard`).
+logging, Prisma, request IDs, errors, and health checks; domain-agnostic
+building blocks such as the pagination contracts live in `src/shared/`. Better
+Auth owns native authentication while the starter owns the meaning and
+enforcement of `USER` and `ADMIN` roles, kept independent through the global
+guard chain that `AppModule` registers (`RateLimitGuard` → `SessionGuard` →
+`RolesGuard` → `OriginGuard`), in that order, because `RolesGuard` reads the
+principal `SessionGuard` attaches to the request.
+
+Nothing under `src/core/` or `src/shared/` imports from `src/features/`, so
+global infrastructure stays composable without any business feature. A feature
+that has to join the request pipeline implements the `HttpExtension` port
+(`src/core/http/http-extension.ts`) instead. `pnpm verify:boundaries` enforces
+that rule and runs as its own CI step.
 
 - [`docs/PRD.md`](./docs/PRD.md) — product requirements.
 - [`docs/PRODUCT_SPEC.md`](./docs/PRODUCT_SPEC.md) — the observable API


### PR DESCRIPTION
Closes #33

## The problem

The README was asked for one missing command. It turned out to be describing an architecture that no longer exists.

#30 corrected `AGENTS.md` and `docs/EDD.md` and missed `README.md` — which is the worst of the three to miss, because it is the first thing someone reads after cloning a template.

## The fix

| Claim | Was | Is |
|---|---|---|
| Pagination contracts | provided by `PlatformModule` | live in `src/shared/` |
| Global guard chain | owned by `AccessControlModule` | registered by `AppModule`, the composition root |
| Guard order | listed, unexplained | listed, with why it is load-bearing: `RolesGuard` reads the principal `SessionGuard` attaches |
| `pnpm verify:boundaries` | absent | in the command table |
| Core-to-feature rule | unmentioned | stated, with the `HttpExtension` port and where it is enforced |

## Test plan

- [x] Swept every doc for the stale identifiers — `core/pagination`, `core/prisma/admin-seed`, `features/auth/decorators/public`, `AccessControlModule` as guard owner — across `README.md`, `AGENTS.md` and `docs/`: no matches left
- [x] Verified all **14** commands in the README table resolve to a script in `package.json`

## Note for the reviewer

The command check was worth doing twice. The first pattern was `^\| \`pnpm ([a-z:]+)\``, which cannot match the `2` in `test:e2e` — so that row was skipped and the run still printed a clean list of 13. Re-run with `[a-z0-9:]+`: 14 rows in the table, 14 extracted, 14 found.

Same failure shape as the `! grep` hole in #32, in the throwaway verification rather than the shipped guard: a check that silently examines less than you think it does, and reports success either way. Worth stating rather than quietly fixing, because the tell was the count — 13 against a table of 14 — and nothing else.
