### PR TITLE
fix(swagger): scope auth operations to the cookie security scheme

### DIFF
--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -153,7 +153,15 @@ in development and test. Nest shutdown hooks stop
 accepting new work, drain in-flight requests, then call Prisma's module
 destruction hook to disconnect. Swagger documents starter-owned health and
 user routes under their versioned paths; Better Auth owns its native
-authentication route contract.
+authentication route contract. Better Auth's own OpenAPI output documents a
+bearer flow this starter does not implement, so `mergeAuthOpenApiDocument`
+(`src/features/auth/better-auth.service.ts`) republishes the documented
+authentication operations against the starter's `cookie` scheme — empty for
+sign-up and sign-in, which issue a session rather than requiring one — and
+copies Better Auth's schemas but never its security schemes. Swagger UI is
+configured to send credentials and persist authorization, because its Authorize
+dialog cannot set a session cookie: browsers forbid scripts from setting the
+`Cookie` header, so the real flow is to execute sign-in from the docs page.
 
 ## 6. Testing
 

--- a/src/core/http/configure-application.spec.ts
+++ b/src/core/http/configure-application.spec.ts
@@ -70,6 +70,7 @@ describe('configureApplication', () => {
       'docs',
       expect.anything(),
       expect.anything(),
+      { swaggerOptions: { persistAuthorization: true, withCredentials: true } },
     );
     expect(createDocument.mock.calls[0]?.[1]).toMatchObject({
       components: {
@@ -82,6 +83,33 @@ describe('configureApplication', () => {
         },
       },
     });
+    createDocument.mockRestore();
+    setup.mockRestore();
+  });
+
+  it('When not in production, then the description explains that the Authorize dialog cannot set the session cookie', async () => {
+    const createDocument = vi
+      .spyOn(SwaggerModule, 'createDocument')
+      .mockReturnValue({ components: { schemas: {} }, paths: {} } as never);
+    const setup = vi.spyOn(SwaggerModule, 'setup').mockImplementation(() => {});
+    const config = {
+      getOrThrow: (key: string) =>
+        key === 'NODE_ENV'
+          ? 'development'
+          : key === 'CORS_ORIGINS'
+            ? 'http://localhost:3001'
+            : undefined,
+    };
+
+    await configureApplication(makeApp(config) as never);
+
+    const built = createDocument.mock.calls[0]?.[1] as
+      { info: { description: string } } | undefined;
+    const description = built?.info.description ?? '';
+    expect(description).toContain('User administration API');
+    expect(description).toContain('Authorize dialog cannot set');
+    expect(description).toContain('Cookie header');
+    expect(description).toContain('/api/auth/sign-in/email');
     createDocument.mockRestore();
     setup.mockRestore();
   });

--- a/src/core/http/configure-application.ts
+++ b/src/core/http/configure-application.ts
@@ -57,7 +57,11 @@ export async function configureApplication(
         .setTitle('Backend Starter API')
         .setDescription(
           'User administration API protected by Better Auth session cookies. ' +
-            'Native authentication routes are mounted at /api/auth.',
+            'Native authentication routes are mounted at /api/auth. ' +
+            'The Authorize dialog cannot set that cookie — browsers forbid ' +
+            'scripts from setting the Cookie header — so authenticate by ' +
+            'executing POST /api/auth/sign-in/email from this page and the ' +
+            'browser will send the session cookie on every later request.',
         )
         .setVersion('1.0')
         .addCookieAuth('better-auth.session_token')
@@ -69,6 +73,8 @@ export async function configureApplication(
 
     await httpExtension.contributeOpenApiDocument(document);
 
-    SwaggerModule.setup('docs', app, document);
+    SwaggerModule.setup('docs', app, document, {
+      swaggerOptions: { persistAuthorization: true, withCredentials: true },
+    });
   }
 }

--- a/src/features/auth/better-auth.service.spec.ts
+++ b/src/features/auth/better-auth.service.spec.ts
@@ -1,5 +1,68 @@
+import type { OpenAPIObject } from '@nestjs/swagger';
 import { describe, expect, it } from 'vitest';
-import { deriveCookieAttributes } from './better-auth.service';
+import {
+  AUTH_BASE_PATH,
+  deriveCookieAttributes,
+  mergeAuthOpenApiDocument,
+} from './better-auth.service';
+
+/**
+ * Mirrors the shape Better Auth's `openAPI()` plugin emits: every operation
+ * carries a bearer requirement against schemes this starter never implements.
+ */
+function createAuthSchema() {
+  const operation = () => ({
+    security: [{ bearerAuth: [] }],
+    tags: ['Default'],
+  });
+  return {
+    components: {
+      schemas: { SignUpEmailBody: { type: 'object' } },
+      securitySchemes: {
+        apiKeyCookie: { type: 'apiKey', in: 'cookie', name: 'apiKeyCookie' },
+        bearerAuth: { type: 'http', scheme: 'bearer' },
+      },
+    },
+    paths: {
+      '/sign-up/email': { post: operation() },
+      '/sign-in/email': { post: operation() },
+      '/sign-out': { post: operation() },
+      '/get-session': { get: operation(), post: operation() },
+      '/ok': { get: operation() },
+    },
+  };
+}
+
+function createStarterDocument(): OpenAPIObject {
+  return {
+    openapi: '3.0.0',
+    info: { title: 'Backend Starter API', version: '1.0' },
+    components: {
+      schemas: { UserResponseDto: { type: 'object' } },
+      securitySchemes: {
+        cookie: {
+          type: 'apiKey',
+          in: 'cookie',
+          name: 'better-auth.session_token',
+        },
+      },
+    },
+    paths: {
+      '/api/v1/users/me': {
+        get: { responses: {}, security: [{ cookie: [] }] },
+      },
+    },
+  };
+}
+
+function collectSecuritySchemeNames(document: OpenAPIObject): string[] {
+  return Object.values(document.paths)
+    .flatMap((item) => Object.values(item))
+    .flatMap((operation: { security?: Record<string, unknown>[] }) =>
+      Array.isArray(operation?.security) ? operation.security : [],
+    )
+    .flatMap((requirement) => Object.keys(requirement));
+}
 
 describe('deriveCookieAttributes', () => {
   it('When the topology is same-site outside production, then the cookie is Lax and not Secure', () => {
@@ -31,5 +94,102 @@ describe('deriveCookieAttributes', () => {
       sameSite: 'none',
       secure: true,
     });
+  });
+});
+
+describe('mergeAuthOpenApiDocument', () => {
+  it('When an authentication route needs a session, then it is published against the cookie scheme the starter declares', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(document.paths[`${AUTH_BASE_PATH}/get-session`]).toMatchObject({
+      get: { security: [{ cookie: [] }], tags: ['auth'] },
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/sign-out`]).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+  });
+
+  it('When an authentication route issues a session, then it is published without a security requirement', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(document.paths[`${AUTH_BASE_PATH}/sign-up/email`]).toMatchObject({
+      post: { security: [], tags: ['auth'] },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/sign-in/email`]).toMatchObject({
+      post: { security: [], tags: ['auth'] },
+    });
+  });
+
+  it('When a path item carries non-operation keys, then only its operations are rewritten', () => {
+    const document = createStarterDocument();
+    const schema = createAuthSchema();
+    const parameters = [{ in: 'header', name: 'x-trace-id' }];
+    const item = {
+      ...schema.paths['/get-session'],
+      description: 'Reads the current session.',
+      parameters,
+      summary: 'Current session',
+    };
+
+    mergeAuthOpenApiDocument(
+      document,
+      { ...schema, paths: { ...schema.paths, '/get-session': item } },
+      AUTH_BASE_PATH,
+    );
+
+    const published = document.paths[`${AUTH_BASE_PATH}/get-session`] as Record<
+      string,
+      unknown
+    >;
+    expect(published.parameters).toEqual(parameters);
+    expect(published.summary).toBe('Current session');
+    expect(published.description).toBe('Reads the current session.');
+    expect(published.parameters).not.toHaveProperty('tags');
+    expect(published.get).toMatchObject({ tags: ['auth'] });
+  });
+
+  it('When Better Auth declares its own security schemes, then they are not published', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(Object.keys(document.components?.securitySchemes ?? {})).toEqual([
+      'cookie',
+    ]);
+    expect(Object.keys(document.components?.schemas ?? {})).toEqual(
+      expect.arrayContaining(['SignUpEmailBody', 'UserResponseDto']),
+    );
+  });
+
+  it('When the document is published, then no operation names an undeclared security scheme', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    const declared = Object.keys(document.components?.securitySchemes ?? {});
+    const referenced = collectSecuritySchemeNames(document);
+    expect(referenced).not.toHaveLength(0);
+    for (const name of referenced) {
+      expect(declared).toContain(name);
+    }
+  });
+
+  it('When Better Auth exposes routes the starter does not document, then they stay unpublished', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(Object.keys(document.paths)).toEqual([
+      '/api/v1/users/me',
+      `${AUTH_BASE_PATH}/sign-up/email`,
+      `${AUTH_BASE_PATH}/sign-in/email`,
+      `${AUTH_BASE_PATH}/sign-out`,
+      `${AUTH_BASE_PATH}/get-session`,
+    ]);
   });
 });

--- a/src/features/auth/better-auth.service.ts
+++ b/src/features/auth/better-auth.service.ts
@@ -22,6 +22,74 @@ const DOCUMENTED_AUTH_PATHS = new Set([
   '/get-session',
 ]);
 
+/** Documented routes that issue a session rather than requiring one. */
+const SESSION_ISSUING_AUTH_PATHS = new Set([
+  '/sign-up/email',
+  '/sign-in/email',
+]);
+
+/** The only path item keys that hold an OpenAPI operation object. */
+const OPERATION_KEYS = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'options',
+  'head',
+  'trace',
+]);
+
+type AuthOpenApiSchema = {
+  components?: {
+    schemas?: NonNullable<OpenAPIObject['components']>['schemas'];
+  };
+  paths?: Record<string, object>;
+};
+
+function normalizeAuthPathItem(
+  path: string,
+  item: object,
+): OpenAPIObject['paths'][string] {
+  const security = SESSION_ISSUING_AUTH_PATHS.has(path) ? [] : [{ cookie: [] }];
+  const normalized: Record<string, unknown> = { ...item };
+  for (const [key, operation] of Object.entries(item)) {
+    if (!OPERATION_KEYS.has(key)) {
+      continue;
+    }
+    normalized[key] = {
+      ...(operation as Record<string, unknown>),
+      security,
+      tags: ['auth'],
+    };
+  }
+  return normalized as OpenAPIObject['paths'][string];
+}
+
+/**
+ * Publishes the documented Better Auth routes under `basePath`, restated
+ * against the session cookie scheme the starter's own document declares.
+ * Better Auth documents a bearer flow this starter does not implement, so only
+ * its schemas cross over — never its security schemes or requirements.
+ */
+export function mergeAuthOpenApiDocument(
+  document: OpenAPIObject,
+  schema: AuthOpenApiSchema,
+  basePath: string,
+): void {
+  for (const [path, item] of Object.entries(schema.paths ?? {})) {
+    if (!DOCUMENTED_AUTH_PATHS.has(path)) {
+      continue;
+    }
+    document.paths[`${basePath}${path}`] = normalizeAuthPathItem(path, item);
+  }
+  document.components ??= {};
+  document.components.schemas = {
+    ...document.components.schemas,
+    ...schema.components?.schemas,
+  };
+}
+
 type CookieAttributes = {
   httpOnly: true;
   partitioned?: true;
@@ -124,22 +192,7 @@ export class BetterAuthService implements HttpExtension {
 
   async contributeOpenApiDocument(document: OpenAPIObject): Promise<void> {
     const schema = await this.generateOpenApiSchema();
-    for (const [path, item] of Object.entries(schema.paths ?? {})) {
-      if (!DOCUMENTED_AUTH_PATHS.has(path)) {
-        continue;
-      }
-      for (const operation of Object.values(
-        item as Record<string, { tags?: string[] }>,
-      )) {
-        operation.tags = ['auth'];
-      }
-      document.paths[`${this.basePath}${path}`] =
-        item as OpenAPIObject['paths'][string];
-    }
-    Object.assign(
-      document.components?.schemas ?? {},
-      schema.components?.schemas,
-    );
+    mergeAuthOpenApiDocument(document, schema, this.basePath);
   }
 
   async getSession(request: Request, response: Response) {

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -1,6 +1,7 @@
 import { execFile as executeFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { OpenAPIObject } from '@nestjs/swagger';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../../src/generated/prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -85,6 +86,17 @@ describe('Better Auth authentication (e2e)', () => {
           role: 'USER',
         }),
       );
+
+    const docs = await request(app.getHttpServer())
+      .get('/docs-json')
+      .expect(200);
+    const document = docs.body as OpenAPIObject;
+    expect(document.paths['/api/auth/sign-in/email']).toMatchObject({
+      post: { security: [] },
+    });
+    expect(document.paths[`${API_VERSIONED_PREFIX}/users/me`]).toMatchObject({
+      get: { security: [{ cookie: [] }] },
+    });
   });
 
   it('When a session user is deleted, then its cascaded session no longer authenticates protected routes', async () => {

--- a/test/e2e/http-platform.spec.ts
+++ b/test/e2e/http-platform.spec.ts
@@ -425,6 +425,64 @@ describe('HTTP platform (e2e)', () => {
     expect(paths.some((path) => /^\/health(\/|$)/.test(path))).toBe(false);
   });
 
+  it('When the application is not in production, then every published operation names a declared security scheme', async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await configureApplication(app);
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .get('/docs-json')
+      .expect(200);
+    const document = response.body as OpenAPIObject;
+    const declared = Object.keys(document.components?.securitySchemes ?? {});
+    const referenced = Object.values(document.paths)
+      .flatMap((item) => Object.values(item))
+      .flatMap((operation: { security?: Record<string, unknown>[] }) =>
+        Array.isArray(operation?.security) ? operation.security : [],
+      )
+      .flatMap((requirement) => Object.keys(requirement));
+
+    expect(declared).toContain('cookie');
+    expect(referenced).not.toHaveLength(0);
+    expect([...new Set(referenced)].sort()).toEqual(declared.sort());
+  });
+
+  it('When the application is not in production, then OpenAPI scopes authentication routes to the session cookie', async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await configureApplication(app);
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .get('/docs-json')
+      .expect(200);
+    const document = response.body as OpenAPIObject;
+
+    expect(document.paths['/api/auth/sign-up/email']).toMatchObject({
+      post: { security: [], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/sign-in/email']).toMatchObject({
+      post: { security: [], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/sign-out']).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/get-session']).toMatchObject({
+      get: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.components?.securitySchemes).not.toHaveProperty(
+      'bearerAuth',
+    );
+    expect(document.components?.securitySchemes).not.toHaveProperty(
+      'apiKeyCookie',
+    );
+  });
+
   it('When a required configuration value is absent, then application initialization fails', () => {
     const environment = { ...process.env };
     delete environment.BETTER_AUTH_SECRET;


### PR DESCRIPTION
## Summary
- Extract the Better Auth → Swagger OpenAPI merge into `mergeAuthOpenApiDocument`, confirmed empirically against Better Auth's real generated schema (every operation carried `security: [{ bearerAuth: [] }]`, referencing a scheme this starter never declares).
- Session-requiring auth operations now publish `security: [{ cookie: [] }]`; sign-up/sign-in publish `security: []`. Better Auth's own `securitySchemes` (bearer) are no longer copied in — only its `components.schemas` are merged.
- Tag assignment now only touches real HTTP operation keys, not every value of a path item.
- Swagger UI is configured with `withCredentials`/`persistAuthorization`, and the document description explains that the Authorize dialog can't set a cookie (browsers forbid it) — sign in from the page instead.
- `DOCUMENTED_AUTH_PATHS` unchanged; no route surface changes.

Closes #37

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (89 unit tests, incl. new `mergeAuthOpenApiDocument` cases covering security scoping, non-operation-key safety, and a whole-document "every referenced scheme is declared" invariant)
- [x] `pnpm test:integration`
- [x] `pnpm test:e2e` (extended to assert `/docs-json` security shapes and the sign-in → protected-route flow)
- [x] `pnpm verify:boundaries`
- Reviewed via `/code-review` (Standards + Spec axes, no hard violations)
- Note: AC "sign in from the docs page and call a protected route from the same page" is proven at the HTTP level (cookie propagation, document shapes, `withCredentials`/`persistAuthorization` config) but not through an actual browser click-through — this repo has no browser-level test tooling today.