### PR TITLE
docs(adr): record cookie-session-for-SPA decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ in through its native JSON endpoints; successful authentication returns an
 HTTP-only session cookie. Send that cookie on requests to protected starter
 routes such as `/api/v1/users/me`.
 
+The session cookie targets a browser SPA, and that is a deliberate choice with
+a cost as well as a benefit. A native mobile client is not served by it and
+needs a bearer-token scheme instead; the default is meant to be changed when
+the client is not a browser. See
+[ADR 0002 — cookie sessions for a browser SPA](./docs/adr/0002-cookie-session-for-spa.md)
+for the reasoning, the CSRF tradeoff, and the single seam a bearer-token scheme
+plugs into.
+
 ```bash
 curl -i http://localhost:3000/api/auth/sign-up/email \
   --json '{"name":"Reader","email":"reader@example.com","password":"password-123"}'

--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -86,7 +86,10 @@ requests, where `SameSite=Lax` remains the browser-level protection. Better
 Auth owns the corresponding check for its native routes. Session cookie caching
 (`session.cookieCache`) stays disabled: enabling it would trade the guarantee
 that a role change takes effect on the next protected request for a staleness
-window. `PUBLIC_BASE_URL` feeds Better Auth's `baseURL` and must be `https` when
+window. Why the session is carried by a cookie at all rather than a bearer
+token, what that costs, and what a native client would require instead is
+recorded in [ADR 0002](./adr/0002-cookie-session-for-spa.md).
+`PUBLIC_BASE_URL` feeds Better Auth's `baseURL` and must be `https` when
 `DEPLOYMENT_TOPOLOGY=cross-site` or `NODE_ENV=production`; a configuration
 browsers would reject fails at boot with a message naming the offending
 combination, rather than as a silent `401` in production.

--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -83,12 +83,13 @@ CSRF control for `cross-site`: it delegates an exact `Origin` check to the
 platform `OriginValidator` for `POST`, `PUT`, `PATCH`, and `DELETE` requests to
 any starter-owned route. It remains inert for safe methods and all `same-site`
 requests, where `SameSite=Lax` remains the browser-level protection. Better
-Auth owns the corresponding check for its native routes. Session cookie caching
+Auth owns the corresponding check for its native routes. Why the session is
+carried by a cookie at all rather than a bearer token, what that costs, and
+what a native client would require instead is recorded in
+[ADR 0002](./adr/0002-cookie-session-for-spa.md). Session cookie caching
 (`session.cookieCache`) stays disabled: enabling it would trade the guarantee
 that a role change takes effect on the next protected request for a staleness
-window. Why the session is carried by a cookie at all rather than a bearer
-token, what that costs, and what a native client would require instead is
-recorded in [ADR 0002](./adr/0002-cookie-session-for-spa.md).
+window.
 `PUBLIC_BASE_URL` feeds Better Auth's `baseURL` and must be `https` when
 `DEPLOYMENT_TOPOLOGY=cross-site` or `NODE_ENV=production`; a configuration
 browsers would reject fails at boot with a message naming the offending

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -79,6 +79,9 @@ Starter-owned errors use this shape:
 - A `cross-site` topology, or `NODE_ENV=production`, paired with a non-`https`
   `PUBLIC_BASE_URL` fails application startup instead of issuing a cookie the
   browser will silently reject.
+- Why the Authenticated Client is a browser SPA carrying a cookie rather than a
+  bearer token, what that costs, and what a native client would need instead:
+  [ADR 0002](./adr/0002-cookie-session-for-spa.md).
 
 ## 4. Authorization and Users
 

--- a/docs/adr/0002-cookie-session-for-spa.md
+++ b/docs/adr/0002-cookie-session-for-spa.md
@@ -1,0 +1,62 @@
+# Cookie sessions for a browser SPA: HTTP-only session cookies rather than bearer tokens
+
+Status: accepted
+
+The Authenticated Client this starter is built for is a browser SPA, and it
+authenticates with Better Auth's HTTP-only session cookie. That was a choice
+between two supported options, not the absence of one: Better Auth ships a
+`bearer` plugin next to the `openAPI` plugin this starter already enables, and
+the starter deliberately enables only the latter.
+
+The cookie wins for a browser client because it removes work the SPA would
+otherwise have to get right. There is no token for the client to store, so
+there is no decision about `localStorage` versus memory, and no session lost or
+leaked by choosing wrong — the browser holds the credential and attaches it on
+its own. `HttpOnly` keeps that credential unreadable by injected JavaScript, so
+an XSS foothold can act inside the session but cannot exfiltrate a token that
+outlives the page. And the rolling Session Lifetime renews through the same
+cookie, so there is no refresh-token rotation to implement, no rotation race to
+handle, and no second credential to revoke.
+
+## Consequences
+
+A native mobile client is not served by this default. Mobile has no cookie jar
+the starter can rely on and needs a bearer-token scheme instead. The same is
+true of any non-browser consumer, machine-to-machine callers included: there is
+no second authentication path in this starter today.
+
+That change happens at one seam — the `plugins` array in `createAuthInstance`
+(`src/features/auth/better-auth.service.ts`), which today reads
+`plugins: [openAPI()]`. Adding `bearer()` from `better-auth/plugins`, wired the
+same way `openAPI()` is, is the whole integration point. The plugin runs as a
+`before` hook that rewrites an `Authorization: bearer <token>` header into the
+session cookie on the request before the session is resolved, so
+`BetterAuthService.getSession` and `SessionGuard` keep working unchanged, and
+Better Auth returns the token to the client in a `set-auth-token` response
+header on its native routes. Nothing in the request pipeline moves: the
+`HttpExtension` contract (`src/core/http/http-extension.ts`) and
+`configureApplication` mount the same handler either way. The default is meant
+to be changed when the client is not a browser — not worked around.
+
+The cost of the cookie is CSRF exposure, and it is real. A bearer token in an
+`Authorization` header is attached by the client, so a hostile cross-origin page
+cannot silently make an authenticated request with it. A cookie is attached by
+the browser, so it can. This starter answers that in two places. Under the
+default `same-site` topology, the answer is the cookie attribute itself:
+`SameSite=Lax` means the browser does not send the session cookie on
+cross-site state-changing requests, and that is the primary protection. Under
+`DEPLOYMENT_TOPOLOGY=cross-site` the cookie becomes
+`SameSite=None; Secure; Partitioned` so a client on another registrable domain
+still receives it, which surrenders that browser-level protection outright;
+`OriginGuard` (`src/core/access-control/origin.guard.ts`) replaces it with an
+exact `Origin` check against `CORS_ORIGINS` for `POST`, `PUT`, `PATCH`, and
+`DELETE` on starter-owned routes, and Better Auth applies its own trusted-origin
+check to the native routes at `/api/auth`.
+
+That replacement is not equivalent, and a cross-site deployment should be
+adopted knowing it. An origin check is an application-level control that
+depends on the browser sending `Origin`, on `CORS_ORIGINS` being kept narrow,
+and on state-changing work actually living behind a state-changing method —
+safe methods are not checked. `SameSite=Lax` needs none of that to hold. A
+cross-site topology is therefore a deliberate step down in CSRF posture, taken
+because the deployment requires it, not because the two are equally strong.

--- a/docs/adr/0002-cookie-session-for-spa.md
+++ b/docs/adr/0002-cookie-session-for-spa.md
@@ -28,12 +28,14 @@ no second authentication path in this starter today.
 That change happens at one seam — the `plugins` array in `createAuthInstance`
 (`src/features/auth/better-auth.service.ts`), which today reads
 `plugins: [openAPI()]`. Adding `bearer()` from `better-auth/plugins`, wired the
-same way `openAPI()` is, is the whole integration point. The plugin runs as a
-`before` hook that rewrites an `Authorization: bearer <token>` header into the
-session cookie on the request before the session is resolved, so
-`BetterAuthService.getSession` and `SessionGuard` keep working unchanged, and
-Better Auth returns the token to the client in a `set-auth-token` response
-header on its native routes. Nothing in the request pipeline moves: the
+same way `openAPI()` is, is the whole integration point. Per the installed
+`better-auth` package's own plugin source (`better-auth/plugins`, not code this
+starter owns), the plugin runs as a `before` hook that rewrites an
+`Authorization: bearer <token>` header into the session cookie on the request
+before the session is resolved, so `BetterAuthService.getSession` and
+`SessionGuard` keep working unchanged, and Better Auth returns the token to the
+client in a `set-auth-token` response header on its native routes. Nothing in
+the request pipeline moves: the
 `HttpExtension` contract (`src/core/http/http-extension.ts`) and
 `configureApplication` mount the same handler either way. The default is meant
 to be changed when the client is not a browser — not worked around.


### PR DESCRIPTION
## Summary
- New `docs/adr/0002-cookie-session-for-spa.md`: HTTP-only session cookies were a deliberate choice for the browser-SPA Authenticated Client, argued both ways — the benefits (no token storage, no XSS-readable credential, no refresh-rotation) and the costs (mobile/M2M unserved, the `bearer()` plugin seam, cross-site's CSRF exposure and how `OriginGuard` answers it).
- README's Authentication section, `docs/PRODUCT_SPEC.md`, and `docs/EDD.md` now point at the ADR from the places that already describe cookie behavior, rather than duplicating the argument.

Closes #40

## Test plan
- Documentation-only change, no code touched — no typecheck/tests apply.
- Every technical claim in the ADR (the `plugins: [openAPI()]` seam, `deriveCookieAttributes`, `OriginGuard`/`OriginValidator` CSRF behavior) was verified against the actual source, not assumed.
- Reviewed via `/code-review` (Standards + Spec axes); two follow-up fixes applied after review: moved the EDD pointer so it no longer splices an unrelated topic mid-paragraph, and sourced the `bearer` plugin's runtime-behavior claim to the installed package rather than stating it as this starter's own code.