### PR TITLE
ci: fail the build when the image can't reach readiness

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,3 +57,39 @@ jobs:
         with:
           context: .
           push: false
+          load: true
+          tags: starter-template-nestjs:ci
+
+      - name: Start PostgreSQL for the image
+        run: docker compose --project-name image-check up --detach --wait postgres
+
+      - name: Start the built image
+        run: |
+          docker run --detach \
+            --name image-check-app \
+            --network image-check_default \
+            --publish 3000:3000 \
+            --env DATABASE_URL=postgresql://backend_starter:backend_starter@postgres:5432/backend_starter \
+            --env BETTER_AUTH_SECRET=ci-only-better-auth-secret-not-used-anywhere-else \
+            --env CORS_ORIGINS=http://localhost:3000 \
+            --env PUBLIC_BASE_URL=https://localhost \
+            --env PORT=3000 \
+            starter-template-nestjs:ci
+
+      - name: Verify the built image serves readiness
+        id: readiness
+        run: |
+          curl --fail --silent --show-error \
+            --max-time 10 \
+            --retry 30 --retry-delay 2 --retry-all-errors --retry-connrefused \
+            http://localhost:3000/api/v1/health/ready
+
+      - name: Report why the built image never became ready
+        if: failure() && steps.readiness.outcome == 'failure'
+        run: docker logs image-check-app
+
+      - name: Stop the image and its database
+        if: always()
+        run: |
+          docker rm --force image-check-app
+          docker compose --project-name image-check down --volumes

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           curl --fail --silent --show-error \
             --max-time 10 \
-            --retry 30 --retry-delay 2 --retry-all-errors --retry-connrefused \
+            --retry 30 --retry-delay 2 --retry-max-time 90 \
+            --retry-all-errors --retry-connrefused \
             http://localhost:3000/api/v1/health/ready
 
       - name: Report why the built image never became ready


### PR DESCRIPTION
## Summary
- The `verify` job now builds the image with `load: true`, boots it against a Postgres started from the existing `docker-compose.yml` service, and polls `GET /api/v1/health/ready` until it returns 200 (or the retry budget is exhausted).
- On failure the job dumps `docker logs` from the app container before cleanup, so the cause is visible in the CI run.
- No change to the Dockerfile or Compose file, as required by the ticket.

Closes #41

## Test plan
- [x] Local dry run of every added command (build, compose up --wait, docker run with the required env, curl readiness, teardown) — the current production image boots cleanly and returns `{"status":"ok","checks":{"postgres":"up"}}`.
- [x] Verified the failure path actually fails: pointed the container at an unreachable DB host and confirmed curl exits non-zero (503 → `--fail` → exit 22) rather than the job silently passing.
- [x] YAML validated with `python3 -c "import yaml; ..."` and `actionlint` (both clean).
- Reviewed via `/code-review` (Standards + Spec axes); one follow-up fix applied after review: `--max-time` only bounds a single attempt, so added an explicit `--retry-max-time 90` to bound the whole retry budget rather than relying on undocumented cross-version curl behavior.