### PR TITLE
feat(swagger): replace the auth path allowlist with published/excluded registries

### DIFF
--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -18,10 +18,20 @@ Better Auth owns the native authentication API mounted at `/api/auth`.
 | `POST` | `/api/auth/sign-in/email` | Create a browser session. |
 | `POST` | `/api/auth/sign-out` | End the current session. |
 | `GET` | `/api/auth/get-session` | Return the active session when present. |
+| `GET` | `/api/auth/list-sessions` | List the caller's active sessions. |
+| `POST` | `/api/auth/revoke-session` | Revoke one session by its token. |
+| `POST` | `/api/auth/revoke-sessions` | Revoke every session, including the caller's own. |
+| `POST` | `/api/auth/revoke-other-sessions` | Revoke every session except the caller's own. |
 
 Authentication routes use Better Auth request, success, cookie, and error
 shapes. The starter does not adapt those responses. Sign-up requires `name`,
 `email`, and `password`; sign-in requires `email` and `password`.
+
+Better Auth generates other routes this starter does not enable and therefore
+does not publish — social sign-in, email change, account deletion, password
+reset, and email verification each require configuration the starter leaves
+unset. `src/features/auth/better-auth.service.ts` names each one and the
+configuration that would enable it.
 
 ### Starter-Owned Routes
 

--- a/src/features/auth/better-auth.service.spec.ts
+++ b/src/features/auth/better-auth.service.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   AUTH_BASE_PATH,
   deriveCookieAttributes,
+  findUnaccountedAuthPaths,
   mergeAuthOpenApiDocument,
 } from './better-auth.service';
 
@@ -28,6 +29,29 @@ function createAuthSchema() {
       '/sign-in/email': { post: operation() },
       '/sign-out': { post: operation() },
       '/get-session': { get: operation(), post: operation() },
+      '/list-sessions': { get: operation() },
+      '/revoke-session': {
+        post: {
+          ...operation(),
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/RevokeSessionBody' },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: 'Session revoked',
+              content: {
+                'application/json': { schema: { type: 'object' } },
+              },
+            },
+          },
+        },
+      },
+      '/revoke-sessions': { post: operation() },
+      '/revoke-other-sessions': { post: operation() },
       '/ok': { get: operation() },
     },
   };
@@ -190,6 +214,69 @@ describe('mergeAuthOpenApiDocument', () => {
       `${AUTH_BASE_PATH}/sign-in/email`,
       `${AUTH_BASE_PATH}/sign-out`,
       `${AUTH_BASE_PATH}/get-session`,
+      `${AUTH_BASE_PATH}/list-sessions`,
+      `${AUTH_BASE_PATH}/revoke-session`,
+      `${AUTH_BASE_PATH}/revoke-sessions`,
+      `${AUTH_BASE_PATH}/revoke-other-sessions`,
     ]);
+  });
+
+  it('When the session-management routes need a session, then they are published against the cookie scheme', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(document.paths[`${AUTH_BASE_PATH}/list-sessions`]).toMatchObject({
+      get: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/revoke-session`]).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(
+      document.paths[`${AUTH_BASE_PATH}/revoke-sessions`],
+    ).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(
+      document.paths[`${AUTH_BASE_PATH}/revoke-other-sessions`],
+    ).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+  });
+
+  it('When a published route carries a request body and response schema, then both survive the merge', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    const published = document.paths[`${AUTH_BASE_PATH}/revoke-session`] as {
+      post: { requestBody: unknown; responses: unknown };
+    };
+    expect(published.post.requestBody).toMatchObject({
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/RevokeSessionBody' },
+        },
+      },
+    });
+    expect(published.post.responses).toMatchObject({
+      200: { description: 'Session revoked' },
+    });
+  });
+});
+
+describe('findUnaccountedAuthPaths', () => {
+  it('When every generated path is either published or excluded, then nothing is unaccounted', () => {
+    const schema = createAuthSchema();
+
+    expect(
+      findUnaccountedAuthPaths([...Object.keys(schema.paths), '/delete-user']),
+    ).toEqual([]);
+  });
+
+  it('When Better Auth generates a path neither registry names, then it is reported', () => {
+    expect(
+      findUnaccountedAuthPaths(['/get-session', '/a-brand-new-route']),
+    ).toEqual(['/a-brand-new-route']);
   });
 });

--- a/src/features/auth/better-auth.service.spec.ts
+++ b/src/features/auth/better-auth.service.spec.ts
@@ -232,9 +232,7 @@ describe('mergeAuthOpenApiDocument', () => {
     expect(document.paths[`${AUTH_BASE_PATH}/revoke-session`]).toMatchObject({
       post: { security: [{ cookie: [] }], tags: ['auth'] },
     });
-    expect(
-      document.paths[`${AUTH_BASE_PATH}/revoke-sessions`],
-    ).toMatchObject({
+    expect(document.paths[`${AUTH_BASE_PATH}/revoke-sessions`]).toMatchObject({
       post: { security: [{ cookie: [] }], tags: ['auth'] },
     });
     expect(

--- a/src/features/auth/better-auth.service.ts
+++ b/src/features/auth/better-auth.service.ts
@@ -138,7 +138,7 @@ const EXCLUDED_AUTH_PATHS: ReadonlyArray<{ path: string; reason: string }> = [
   {
     path: '/verify-email',
     reason:
-      'Guarded by `emailVerification.sendVerificationEmail` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
+      'Consumes the token `/send-verification-email` mints; that route throws BAD_REQUEST while `emailVerification.sendVerificationEmail` is unset, so no valid token is ever issued.',
   },
   {
     path: '/verify-password',
@@ -156,9 +156,7 @@ const EXCLUDED_AUTH_PATH_SET = new Set(
  * means {@link PUBLISHED_AUTH_PATHS} and {@link EXCLUDED_AUTH_PATHS}
  * completely describe what Better Auth currently generates.
  */
-export function findUnaccountedAuthPaths(
-  paths: Iterable<string>,
-): string[] {
+export function findUnaccountedAuthPaths(paths: Iterable<string>): string[] {
   return [...paths].filter(
     (path) =>
       !PUBLISHED_AUTH_PATHS.has(path) && !EXCLUDED_AUTH_PATH_SET.has(path),

--- a/src/features/auth/better-auth.service.ts
+++ b/src/features/auth/better-auth.service.ts
@@ -15,12 +15,155 @@ import { PrismaService } from '../../core/prisma/prisma.service';
 export const AUTH_BASE_PATH = `/${API_GLOBAL_PREFIX}/auth`;
 
 /** Better Auth routes this starter documents in its OpenAPI schema. */
-const DOCUMENTED_AUTH_PATHS = new Set([
+const PUBLISHED_AUTH_PATHS = new Set([
   '/sign-up/email',
   '/sign-in/email',
   '/sign-out',
   '/get-session',
+  '/list-sessions',
+  '/revoke-session',
+  '/revoke-sessions',
+  '/revoke-other-sessions',
 ]);
+
+/**
+ * Better Auth routes this starter deliberately withholds from the published
+ * document, with the configuration that would turn each into a real
+ * capability. This registry plus {@link PUBLISHED_AUTH_PATHS} must account
+ * for every path Better Auth's `openAPI()` plugin generates — enforced by
+ * {@link findUnaccountedAuthPaths} — so upgrading Better Auth and picking up
+ * a new route fails loudly instead of silently drifting from the document.
+ */
+const EXCLUDED_AUTH_PATHS: ReadonlyArray<{ path: string; reason: string }> = [
+  {
+    path: '/account-info',
+    reason:
+      "Reads a linked OAuth provider's account info; returns nothing useful until `socialProviders` configures a provider.",
+  },
+  {
+    path: '/callback/{id}',
+    reason:
+      'OAuth callback for a given provider id; unreachable until `socialProviders` configures that provider.',
+  },
+  {
+    path: '/change-email',
+    reason:
+      'Guarded by `user.changeEmail.enabled` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
+  },
+  {
+    path: '/change-password',
+    reason:
+      'Core route, already functional with no gating config; withheld because self-service profile management is outside this ticket’s session-management scope.',
+  },
+  {
+    path: '/delete-user',
+    reason:
+      'Guarded by `user.deleteUser.enabled` — Better Auth throws NOT_FOUND while it is unset, which this starter leaves unset.',
+  },
+  {
+    path: '/delete-user/callback',
+    reason:
+      'Completes the `/delete-user` verification flow; inert for the same reason — `user.deleteUser.enabled` is unset.',
+  },
+  {
+    path: '/error',
+    reason:
+      "Better Auth's own HTML error page for OAuth redirects; not gated by configuration and irrelevant to a JSON API.",
+  },
+  {
+    path: '/get-access-token',
+    reason:
+      "Refreshes a linked provider's OAuth token; requires `socialProviders` to configure that provider.",
+  },
+  {
+    path: '/link-social',
+    reason:
+      'Links a social account to the signed-in user; requires `socialProviders` to configure a provider.',
+  },
+  {
+    path: '/list-accounts',
+    reason:
+      "Lists the user's linked OAuth accounts; always empty until `socialProviders` configures a provider.",
+  },
+  {
+    path: '/ok',
+    reason:
+      "Better Auth's own liveness probe; the starter documents its own health routes instead.",
+  },
+  {
+    path: '/refresh-token',
+    reason:
+      'Refreshes an OAuth provider access token; requires `socialProviders` to configure that provider.',
+  },
+  {
+    path: '/request-password-reset',
+    reason:
+      'Guarded by `emailAndPassword.sendResetPassword` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
+  },
+  {
+    path: '/reset-password',
+    reason:
+      'Consumes the token `/request-password-reset` issues; inert for the same reason — `emailAndPassword.sendResetPassword` is unset.',
+  },
+  {
+    path: '/reset-password/{token}',
+    reason:
+      'The redirect landing for the reset-password email link; inert for the same reason — `emailAndPassword.sendResetPassword` is unset.',
+  },
+  {
+    path: '/send-verification-email',
+    reason:
+      'Guarded by `emailVerification.sendVerificationEmail` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
+  },
+  {
+    path: '/sign-in/social',
+    reason:
+      'Starts an OAuth sign-in; requires `socialProviders` to configure a provider.',
+  },
+  {
+    path: '/unlink-account',
+    reason:
+      'Unlinks a social account; requires `socialProviders` to configure a provider before any account can be linked.',
+  },
+  {
+    path: '/update-session',
+    reason:
+      'Core route, already functional with no gating config; withheld because updating session metadata is outside this ticket’s session-management scope, which covers listing and revoking.',
+  },
+  {
+    path: '/update-user',
+    reason:
+      'Core route, already functional with no gating config; withheld because self-service profile management is outside this ticket’s session-management scope.',
+  },
+  {
+    path: '/verify-email',
+    reason:
+      'Guarded by `emailVerification.sendVerificationEmail` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
+  },
+  {
+    path: '/verify-password',
+    reason:
+      'Core route, already functional with no gating config; withheld because self-service credential checks are outside this ticket’s session-management scope.',
+  },
+];
+
+const EXCLUDED_AUTH_PATH_SET = new Set(
+  EXCLUDED_AUTH_PATHS.map((route) => route.path),
+);
+
+/**
+ * Returns every path in `paths` that neither registry accounts for. Empty
+ * means {@link PUBLISHED_AUTH_PATHS} and {@link EXCLUDED_AUTH_PATHS}
+ * completely describe what Better Auth currently generates.
+ */
+export function findUnaccountedAuthPaths(
+  paths: Iterable<string>,
+): string[] {
+  return [...paths].filter(
+    (path) =>
+      !PUBLISHED_AUTH_PATHS.has(path) && !EXCLUDED_AUTH_PATH_SET.has(path),
+  );
+}
 
 /** Documented routes that issue a session rather than requiring one. */
 const SESSION_ISSUING_AUTH_PATHS = new Set([
@@ -78,7 +221,7 @@ export function mergeAuthOpenApiDocument(
   basePath: string,
 ): void {
   for (const [path, item] of Object.entries(schema.paths ?? {})) {
-    if (!DOCUMENTED_AUTH_PATHS.has(path)) {
+    if (!PUBLISHED_AUTH_PATHS.has(path)) {
       continue;
     }
     document.paths[`${basePath}${path}`] = normalizeAuthPathItem(path, item);

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -9,6 +9,10 @@ import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { API_VERSIONED_PREFIX } from '../../src/core/http/api-version';
 import { configureApplication } from '../../src/core/http/configure-application';
+import {
+  BetterAuthService,
+  findUnaccountedAuthPaths,
+} from '../../src/features/auth/better-auth.service';
 import { defaultEnvironment } from '../support/default-environment';
 import {
   createTestEnvironment,
@@ -441,5 +445,129 @@ describe('Better Auth authentication (e2e)', () => {
         DATABASE_URL: environment.databaseUrl,
       };
     }
+  });
+
+  it('When Better Auth generates its live OpenAPI schema, then every path is either published or deliberately excluded', async () => {
+    const schema = await app.get(BetterAuthService).generateOpenApiSchema();
+    const unaccounted = findUnaccountedAuthPaths(Object.keys(schema.paths));
+
+    expect(
+      unaccounted,
+      `Better Auth generates path(s) neither PUBLISHED_AUTH_PATHS nor EXCLUDED_AUTH_PATHS accounts for: ${unaccounted.join(', ')}. Classify each in src/features/auth/better-auth.service.ts.`,
+    ).toEqual([]);
+  });
+
+  it('When a signed-in user lists their sessions, then the current session is returned', async () => {
+    const email = 'session-lister@example.com';
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-up/email')
+      .send({ name: 'Session lister', email, password: 'password-123' })
+      .expect(200);
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(200);
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+
+    const response = await request(app.getHttpServer())
+      .get('/api/auth/list-sessions')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ userId: expect.any(String) }),
+      ]),
+    );
+  });
+
+  it('When a signed-in user revokes their other sessions, then the calling session stays signed in', async () => {
+    const email = 'revoke-other-sessions@example.com';
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-up/email')
+      .send({ name: 'Revoker', email, password: 'password-123' })
+      .expect(200);
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(200);
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+
+    await request(app.getHttpServer())
+      .post('/api/auth/revoke-other-sessions')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get('/api/auth/get-session')
+      .set('Cookie', cookie)
+      .expect(200)
+      .expect(({ body }) =>
+        expect(body).toMatchObject({ user: { email } }),
+      );
+  });
+
+  it('When a signed-in user revokes one of their sessions, then the endpoint is reachable and succeeds', async () => {
+    const email = 'revoke-one-session@example.com';
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-up/email')
+      .send({ name: 'One revoker', email, password: 'password-123' })
+      .expect(200);
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(200);
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const sessions = await request(app.getHttpServer())
+      .get('/api/auth/list-sessions')
+      .set('Cookie', cookie)
+      .expect(200);
+    const [session] = sessions.body as { token: string }[];
+    if (!session) {
+      throw new Error('Expected at least one session to be listed');
+    }
+
+    await request(app.getHttpServer())
+      .post('/api/auth/revoke-session')
+      .set('Cookie', cookie)
+      .send({ token: session.token })
+      .expect(200);
+  });
+
+  it('When a signed-in user revokes all of their sessions, then the endpoint is reachable and succeeds', async () => {
+    const email = 'revoke-all-sessions@example.com';
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-up/email')
+      .send({ name: 'All revoker', email, password: 'password-123' })
+      .expect(200);
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(200);
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+
+    await request(app.getHttpServer())
+      .post('/api/auth/revoke-sessions')
+      .set('Cookie', cookie)
+      .expect(200);
+  });
+
+  it('When a signed-in user calls the excluded account-deletion route, then it fails as an undocumented capability', async () => {
+    const email = 'delete-user-excluded@example.com';
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-up/email')
+      .send({ name: 'Never deleted', email, password: 'password-123' })
+      .expect(200);
+    const login = await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(200);
+    const cookie = login.headers['set-cookie']?.[0] ?? '';
+
+    await request(app.getHttpServer())
+      .post('/api/auth/delete-user')
+      .set('Cookie', cookie)
+      .send({})
+      .expect(404);
   });
 });

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -21,6 +21,22 @@ import {
 
 const execFile = promisify(executeFile);
 
+/** Signs up and signs in a fresh user, returning its session cookie. */
+async function signUpAndSignIn(
+  app: NestExpressApplication,
+  email: string,
+): Promise<string> {
+  await request(app.getHttpServer())
+    .post('/api/auth/sign-up/email')
+    .send({ name: 'Test user', email, password: 'password-123' })
+    .expect(200);
+  const login = await request(app.getHttpServer())
+    .post('/api/auth/sign-in/email')
+    .send({ email, password: 'password-123' })
+    .expect(200);
+  return login.headers['set-cookie']?.[0] ?? '';
+}
+
 describe('Better Auth authentication (e2e)', () => {
   let app: NestExpressApplication;
   let environment: TestEnvironment;
@@ -458,16 +474,13 @@ describe('Better Auth authentication (e2e)', () => {
   });
 
   it('When a signed-in user lists their sessions, then the current session is returned', async () => {
-    const email = 'session-lister@example.com';
-    await request(app.getHttpServer())
-      .post('/api/auth/sign-up/email')
-      .send({ name: 'Session lister', email, password: 'password-123' })
+    const cookie = await signUpAndSignIn(app, 'session-lister@example.com');
+    const currentSession = await request(app.getHttpServer())
+      .get('/api/auth/get-session')
+      .set('Cookie', cookie)
       .expect(200);
-    const login = await request(app.getHttpServer())
-      .post('/api/auth/sign-in/email')
-      .send({ email, password: 'password-123' })
-      .expect(200);
-    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const currentToken = (currentSession.body as { session: { token: string } })
+      .session.token;
 
     const response = await request(app.getHttpServer())
       .get('/api/auth/list-sessions')
@@ -476,22 +489,14 @@ describe('Better Auth authentication (e2e)', () => {
 
     expect(response.body).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ userId: expect.any(String) }),
+        expect.objectContaining({ token: currentToken }),
       ]),
     );
   });
 
   it('When a signed-in user revokes their other sessions, then the calling session stays signed in', async () => {
     const email = 'revoke-other-sessions@example.com';
-    await request(app.getHttpServer())
-      .post('/api/auth/sign-up/email')
-      .send({ name: 'Revoker', email, password: 'password-123' })
-      .expect(200);
-    const login = await request(app.getHttpServer())
-      .post('/api/auth/sign-in/email')
-      .send({ email, password: 'password-123' })
-      .expect(200);
-    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const cookie = await signUpAndSignIn(app, email);
 
     await request(app.getHttpServer())
       .post('/api/auth/revoke-other-sessions')
@@ -502,22 +507,11 @@ describe('Better Auth authentication (e2e)', () => {
       .get('/api/auth/get-session')
       .set('Cookie', cookie)
       .expect(200)
-      .expect(({ body }) =>
-        expect(body).toMatchObject({ user: { email } }),
-      );
+      .expect(({ body }) => expect(body).toMatchObject({ user: { email } }));
   });
 
   it('When a signed-in user revokes one of their sessions, then the endpoint is reachable and succeeds', async () => {
-    const email = 'revoke-one-session@example.com';
-    await request(app.getHttpServer())
-      .post('/api/auth/sign-up/email')
-      .send({ name: 'One revoker', email, password: 'password-123' })
-      .expect(200);
-    const login = await request(app.getHttpServer())
-      .post('/api/auth/sign-in/email')
-      .send({ email, password: 'password-123' })
-      .expect(200);
-    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const cookie = await signUpAndSignIn(app, 'revoke-one-session@example.com');
     const sessions = await request(app.getHttpServer())
       .get('/api/auth/list-sessions')
       .set('Cookie', cookie)
@@ -535,16 +529,10 @@ describe('Better Auth authentication (e2e)', () => {
   });
 
   it('When a signed-in user revokes all of their sessions, then the endpoint is reachable and succeeds', async () => {
-    const email = 'revoke-all-sessions@example.com';
-    await request(app.getHttpServer())
-      .post('/api/auth/sign-up/email')
-      .send({ name: 'All revoker', email, password: 'password-123' })
-      .expect(200);
-    const login = await request(app.getHttpServer())
-      .post('/api/auth/sign-in/email')
-      .send({ email, password: 'password-123' })
-      .expect(200);
-    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const cookie = await signUpAndSignIn(
+      app,
+      'revoke-all-sessions@example.com',
+    );
 
     await request(app.getHttpServer())
       .post('/api/auth/revoke-sessions')
@@ -553,16 +541,10 @@ describe('Better Auth authentication (e2e)', () => {
   });
 
   it('When a signed-in user calls the excluded account-deletion route, then it fails as an undocumented capability', async () => {
-    const email = 'delete-user-excluded@example.com';
-    await request(app.getHttpServer())
-      .post('/api/auth/sign-up/email')
-      .send({ name: 'Never deleted', email, password: 'password-123' })
-      .expect(200);
-    const login = await request(app.getHttpServer())
-      .post('/api/auth/sign-in/email')
-      .send({ email, password: 'password-123' })
-      .expect(200);
-    const cookie = login.headers['set-cookie']?.[0] ?? '';
+    const cookie = await signUpAndSignIn(
+      app,
+      'delete-user-excluded@example.com',
+    );
 
     await request(app.getHttpServer())
       .post('/api/auth/delete-user')

--- a/test/e2e/http-platform.spec.ts
+++ b/test/e2e/http-platform.spec.ts
@@ -419,6 +419,10 @@ describe('HTTP platform (e2e)', () => {
         '/api/auth/sign-in/email',
         '/api/auth/sign-out',
         '/api/auth/get-session',
+        '/api/auth/list-sessions',
+        '/api/auth/revoke-session',
+        '/api/auth/revoke-sessions',
+        '/api/auth/revoke-other-sessions',
       ]),
     );
     expect(paths.some((path) => /^\/users(\/|$)/.test(path))).toBe(false);
@@ -474,6 +478,18 @@ describe('HTTP platform (e2e)', () => {
     });
     expect(document.paths['/api/auth/get-session']).toMatchObject({
       get: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/list-sessions']).toMatchObject({
+      get: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/revoke-session']).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/revoke-sessions']).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths['/api/auth/revoke-other-sessions']).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
     });
     expect(document.components?.securitySchemes).not.toHaveProperty(
       'bearerAuth',


### PR DESCRIPTION
## Summary

- Replaces the hand-maintained `DOCUMENTED_AUTH_PATHS` set with two explicit registries: `PUBLISHED_AUTH_PATHS` (the 4 existing routes plus the session-management family — list/revoke session, revoke all, revoke other) and `EXCLUDED_AUTH_PATHS`, where every withheld route carries a short reason naming the Better Auth configuration that would enable it (verified against the installed `better-auth` source, not assumed).
- Adds `findUnaccountedAuthPaths()` and an e2e drift-guard test that calls Better Auth's real `generateOpenApiSchema()` and fails, naming the path, if a future Better Auth upgrade adds or removes a route neither registry accounts for.
- Proves the account-deletion route (`/delete-user`) actually fails not-found as the exclusion reason predicts, so the reasons are verified, not assumed.
- Proves the four session-management routes are reachable over HTTP with a real session against a PostgreSQL container, and that request bodies/response schemas survive the merge for a representative route.
- Updates `docs/PRODUCT_SPEC.md` with the four new observable routes, per AGENTS.md's rule to update it for auth/session changes.

Closes #38. Based on `fix/openapi-auth-security-scheme` (#45, still open) since #38 is blocked by #37 — the cookie security scheme and merge hardening it depends on live there.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (unit, 93 passing)
- [x] `pnpm test:integration` (2 passing)
- [x] `pnpm test:e2e` (37 passing, incl. the drift-guard and the four session-management routes against a real Postgres container)