### PR TITLE
feat(swagger): document credential and profile routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ persistence, and shared platform capabilities out of the box.
 ## Features
 
 - Native Better Auth routes at `/api/auth` for email/password sign-up,
-  sign-in, sign-out, and session lookup.
+  sign-in, sign-out, password changes and verification, profile updates,
+  identity-provider account listing, and session management.
 - Starter-owned routes served under a versioned `/api/v1` prefix.
 - Seven-day rolling browser sessions renewed at most once per day.
 - `USER` and `ADMIN` authorization for starter-owned user APIs.

--- a/docs/EDD.md
+++ b/docs/EDD.md
@@ -162,6 +162,11 @@ copies Better Auth's schemas but never its security schemes. Swagger UI is
 configured to send credentials and persist authorization, because its Authorize
 dialog cannot set a session cookie: browsers forbid scripts from setting the
 `Cookie` header, so the real flow is to execute sign-in from the docs page.
+The published and excluded route registries account for every Better Auth
+OpenAPI path; the E2E drift guard fails when a generated route belongs to
+neither. The `update-user` operation carries a starter-specific description
+that roles remain starter-owned; Better Auth rejects `role` input because the
+additional field configures `input: false`.
 
 ## 6. Testing
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -18,6 +18,10 @@ Better Auth owns the native authentication API mounted at `/api/auth`.
 | `POST` | `/api/auth/sign-in/email` | Create a browser session. |
 | `POST` | `/api/auth/sign-out` | End the current session. |
 | `GET` | `/api/auth/get-session` | Return the active session when present. |
+| `POST` | `/api/auth/change-password` | Change the active user's password. |
+| `POST` | `/api/auth/verify-password` | Verify the active user's password. |
+| `POST` | `/api/auth/update-user` | Update the active user's profile. |
+| `GET` | `/api/auth/list-accounts` | List the active user's identity-provider accounts. |
 | `GET` | `/api/auth/list-sessions` | List the caller's active sessions. |
 | `POST` | `/api/auth/revoke-session` | Revoke one session by its token. |
 | `POST` | `/api/auth/revoke-sessions` | Revoke every session, including the caller's own. |
@@ -25,7 +29,10 @@ Better Auth owns the native authentication API mounted at `/api/auth`.
 
 Authentication routes use Better Auth request, success, cookie, and error
 shapes. The starter does not adapt those responses. Sign-up requires `name`,
-`email`, and `password`; sign-in requires `email` and `password`.
+`email`, and `password`; sign-in requires `email` and `password`. `POST
+/api/auth/update-user` can update profile fields, but cannot set or change
+`role`: the starter owns `USER` and `ADMIN` role assignment, and Better Auth
+rejects a role submitted through this route.
 
 Better Auth generates other routes this starter does not enable and therefore
 does not publish — social sign-in, email change, account deletion, password

--- a/src/features/auth/better-auth.service.spec.ts
+++ b/src/features/auth/better-auth.service.spec.ts
@@ -29,7 +29,9 @@ function createAuthSchema() {
       '/sign-in/email': { post: operation() },
       '/sign-out': { post: operation() },
       '/get-session': { get: operation(), post: operation() },
+      '/change-password': { post: operation() },
       '/list-sessions': { get: operation() },
+      '/list-accounts': { get: operation() },
       '/revoke-session': {
         post: {
           ...operation(),
@@ -52,6 +54,8 @@ function createAuthSchema() {
       },
       '/revoke-sessions': { post: operation() },
       '/revoke-other-sessions': { post: operation() },
+      '/update-user': { post: operation() },
+      '/verify-password': { post: operation() },
       '/ok': { get: operation() },
     },
   };
@@ -214,10 +218,14 @@ describe('mergeAuthOpenApiDocument', () => {
       `${AUTH_BASE_PATH}/sign-in/email`,
       `${AUTH_BASE_PATH}/sign-out`,
       `${AUTH_BASE_PATH}/get-session`,
+      `${AUTH_BASE_PATH}/change-password`,
       `${AUTH_BASE_PATH}/list-sessions`,
+      `${AUTH_BASE_PATH}/list-accounts`,
       `${AUTH_BASE_PATH}/revoke-session`,
       `${AUTH_BASE_PATH}/revoke-sessions`,
       `${AUTH_BASE_PATH}/revoke-other-sessions`,
+      `${AUTH_BASE_PATH}/update-user`,
+      `${AUTH_BASE_PATH}/verify-password`,
     ]);
   });
 
@@ -239,6 +247,30 @@ describe('mergeAuthOpenApiDocument', () => {
       document.paths[`${AUTH_BASE_PATH}/revoke-other-sessions`],
     ).toMatchObject({
       post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+  });
+
+  it('When credential and profile routes need a session, then they are published against the cookie scheme', () => {
+    const document = createStarterDocument();
+
+    mergeAuthOpenApiDocument(document, createAuthSchema(), AUTH_BASE_PATH);
+
+    expect(document.paths[`${AUTH_BASE_PATH}/change-password`]).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/verify-password`]).toMatchObject({
+      post: { security: [{ cookie: [] }], tags: ['auth'] },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/update-user`]).toMatchObject({
+      post: {
+        description:
+          'The starter owns user roles; this route cannot set or change a role.',
+        security: [{ cookie: [] }],
+        tags: ['auth'],
+      },
+    });
+    expect(document.paths[`${AUTH_BASE_PATH}/list-accounts`]).toMatchObject({
+      get: { security: [{ cookie: [] }], tags: ['auth'] },
     });
   });
 

--- a/src/features/auth/better-auth.service.ts
+++ b/src/features/auth/better-auth.service.ts
@@ -20,10 +20,14 @@ const PUBLISHED_AUTH_PATHS = new Set([
   '/sign-in/email',
   '/sign-out',
   '/get-session',
+  '/change-password',
   '/list-sessions',
+  '/list-accounts',
   '/revoke-session',
   '/revoke-sessions',
   '/revoke-other-sessions',
+  '/update-user',
+  '/verify-password',
 ]);
 
 /**
@@ -51,11 +55,6 @@ const EXCLUDED_AUTH_PATHS: ReadonlyArray<{ path: string; reason: string }> = [
       'Guarded by `user.changeEmail.enabled` — Better Auth throws BAD_REQUEST while it is unset, which this starter leaves unset.',
   },
   {
-    path: '/change-password',
-    reason:
-      'Core route, already functional with no gating config; withheld because self-service profile management is outside this ticket’s session-management scope.',
-  },
-  {
     path: '/delete-user',
     reason:
       'Guarded by `user.deleteUser.enabled` — Better Auth throws NOT_FOUND while it is unset, which this starter leaves unset.',
@@ -79,11 +78,6 @@ const EXCLUDED_AUTH_PATHS: ReadonlyArray<{ path: string; reason: string }> = [
     path: '/link-social',
     reason:
       'Links a social account to the signed-in user; requires `socialProviders` to configure a provider.',
-  },
-  {
-    path: '/list-accounts',
-    reason:
-      "Lists the user's linked OAuth accounts; always empty until `socialProviders` configures a provider.",
   },
   {
     path: '/ok',
@@ -131,19 +125,9 @@ const EXCLUDED_AUTH_PATHS: ReadonlyArray<{ path: string; reason: string }> = [
       'Core route, already functional with no gating config; withheld because updating session metadata is outside this ticket’s session-management scope, which covers listing and revoking.',
   },
   {
-    path: '/update-user',
-    reason:
-      'Core route, already functional with no gating config; withheld because self-service profile management is outside this ticket’s session-management scope.',
-  },
-  {
     path: '/verify-email',
     reason:
       'Consumes the token `/send-verification-email` mints; that route throws BAD_REQUEST while `emailVerification.sendVerificationEmail` is unset, so no valid token is ever issued.',
-  },
-  {
-    path: '/verify-password',
-    reason:
-      'Core route, already functional with no gating config; withheld because self-service credential checks are outside this ticket’s session-management scope.',
   },
 ];
 
@@ -200,6 +184,12 @@ function normalizeAuthPathItem(
     }
     normalized[key] = {
       ...(operation as Record<string, unknown>),
+      ...(path === '/update-user'
+        ? {
+            description:
+              'The starter owns user roles; this route cannot set or change a role.',
+          }
+        : {}),
       security,
       tags: ['auth'],
     };

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -540,6 +540,77 @@ describe('Better Auth authentication (e2e)', () => {
       .expect(200);
   });
 
+  it('When a signed-in user changes their password, then the old password no longer signs in', async () => {
+    const email = 'password-changer@example.com';
+    const cookie = await signUpAndSignIn(app, email);
+
+    await request(app.getHttpServer())
+      .post('/api/auth/change-password')
+      .set('Cookie', cookie)
+      .send({ currentPassword: 'password-123', newPassword: 'password-456' })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-123' })
+      .expect(401);
+    await request(app.getHttpServer())
+      .post('/api/auth/sign-in/email')
+      .send({ email, password: 'password-456' })
+      .expect(200);
+  });
+
+  it('When a signed-in user verifies their password, then correct and incorrect credentials are distinguished', async () => {
+    const cookie = await signUpAndSignIn(app, 'password-verifier@example.com');
+
+    await request(app.getHttpServer())
+      .post('/api/auth/verify-password')
+      .set('Cookie', cookie)
+      .send({ password: 'password-123' })
+      .expect(200);
+    await request(app.getHttpServer())
+      .post('/api/auth/verify-password')
+      .set('Cookie', cookie)
+      .send({ password: 'wrong-password' })
+      .expect(400);
+  });
+
+  it('When a signed-in user updates their profile, then the role remains starter-controlled', async () => {
+    const email = 'profile-updater@example.com';
+    const cookie = await signUpAndSignIn(app, email);
+
+    await request(app.getHttpServer())
+      .post('/api/auth/update-user')
+      .set('Cookie', cookie)
+      .send({ name: 'Updated user' })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .post('/api/auth/update-user')
+      .set('Cookie', cookie)
+      .send({ role: 'ADMIN' })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get('/api/auth/get-session')
+      .set('Cookie', cookie)
+      .expect(200)
+      .expect(({ body }) =>
+        expect(body).toMatchObject({
+          user: { email, name: 'Updated user', role: 'USER' },
+        }),
+      );
+  });
+
+  it('When a signed-in user lists their accounts, then the endpoint is reachable', async () => {
+    const cookie = await signUpAndSignIn(app, 'account-lister@example.com');
+
+    await request(app.getHttpServer())
+      .get('/api/auth/list-accounts')
+      .set('Cookie', cookie)
+      .expect(200);
+  });
+
   it('When a signed-in user calls the excluded account-deletion route, then it fails as an undocumented capability', async () => {
     const cookie = await signUpAndSignIn(
       app,


### PR DESCRIPTION
Closes #39

## Summary
- Publish Better Auth credential and profile routes in Swagger with cookie authentication.
- Document starter-owned role restrictions and updated Authentication API capabilities.
- Cover credential and profile flows with PostgreSQL-backed HTTP E2E tests.

## Verification
- 
- 
 RUN  v4.1.11 /Users/plizarraga/Documents/Workspace/starter-template-nestjs


 Test Files  20 passed (20)
      Tests  94 passed (94)
   Start at  00:37:44
   Duration  1.28s (transform 701ms, setup 167ms, import 7.48s, tests 396ms, environment 1ms)
- 
 RUN  v4.1.11 /Users/plizarraga/Documents/Workspace/starter-template-nestjs


 Test Files  5 passed (5)
      Tests  41 passed (41)
   Start at  00:37:46
   Duration  14.12s (transform 374ms, setup 71ms, import 4.38s, tests 13.49s, environment 0ms)
- OK: src/core src/shared do not reference src/features
- 
- 
 RUN  v4.1.11 /Users/plizarraga/Documents/Workspace/starter-template-nestjs
      Coverage enabled with v8


 Test Files  26 passed (26)
      Tests  137 passed (137)
   Start at  00:38:04
   Duration  15.66s (transform 2.26s, setup 285ms, import 19.15s, tests 20.65s, environment 3ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   99.19 |    87.33 |     100 |   99.18 |                   
 ...access-control |     100 |     87.5 |     100 |     100 |                   
  origin.guard.ts  |     100 |    83.33 |     100 |     100 | 9                 
 src/core/errors   |     100 |       90 |     100 |     100 |                   
  ...ion.filter.ts |     100 |       90 |     100 |     100 | 47                
 src/core/health   |     100 |     87.5 |     100 |     100 |                   
  ...th.service.ts |     100 |       75 |     100 |     100 | 15                
 ...ore/health/dto |     100 |       50 |     100 |     100 |                   
  ...sponse.dto.ts |     100 |       50 |     100 |     100 | 17                
 src/core/http     |     100 |     87.5 |     100 |     100 |                   
  ...or.service.ts |     100 |    83.33 |     100 |     100 | 6                 
 src/core/prisma   |     100 |       50 |     100 |     100 |                   
  ...ma.service.ts |     100 |       50 |     100 |     100 | 8                 
 src/features/auth |     100 |    89.28 |     100 |     100 |                   
  ...th.service.ts |     100 |    88.88 |     100 |     100 | 211,306           
  session.guard.ts |     100 |       90 |     100 |     100 | 13                
 ...es/auth/guards |     100 |       90 |     100 |     100 |                   
  roles.guard.ts   |     100 |       90 |     100 |     100 | 9                 
 ...features/users |     100 |       90 |     100 |     100 |                   
  ...repository.ts |     100 |       85 |     100 |     100 | 56-75             
  users.service.ts |     100 |    92.85 |     100 |     100 | 14                
 ...ures/users/dto |     100 |       70 |     100 |     100 |                   
  ...sponse.dto.ts |     100 |       50 |     100 |     100 | 22-36             
 ...red/pagination |     100 |       50 |     100 |     100 |                   
  ...nation.dto.ts |     100 |       50 |     100 |     100 | 42                
 test/support      |   82.35 |       75 |     100 |   82.35 |                   
  ...nvironment.ts |   82.35 |       75 |     100 |   82.35 | 33,69-70          
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 99.19% ( 369/372 )
Branches     : 87.33% ( 131/150 )
Functions    : 100% ( 80/80 )
Lines        : 99.18% ( 366/369 )
================================================================================